### PR TITLE
fix(coding-agent): #71 — resolve_model api backfill + <provider>/<model> shorthand

### DIFF
--- a/packages/aelix-coding-agent/src/aelix_coding_agent/cli/entry.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/cli/entry.py
@@ -969,16 +969,12 @@ async def _async_main(argv: list[str]) -> int:
         # RUNTIME OVERRIDE layer (highest cascade precedence) on top of the
         # always-wired callback above.
         model = resolve_model(parsed.model, parsed.provider)
-        # NOTE: this ``not model.provider`` guard is STRICTER than pi only
-        # because ``resolve_model`` does not yet parse the ``<provider>/<pattern>``
-        # shorthand (it returns ``Model(provider="")`` for a bare
-        # ``--model openrouter/gpt-4`` with no separate ``--provider``). Pi's
-        # ``resolveModelFromCli`` (main.ts:303-304) splits that form so its
-        # ``model.provider`` is always populated, and its guard fires only when
-        # NO model resolves at all. When the SettingsManager / resolveModelFromCli
-        # port lands, add the ``provider/pattern`` split here so this guard stops
-        # rejecting pi-valid invocations. The OpenRouter-from-env path already
-        # populates ``provider``, so the common case works.
+        # ``resolve_model`` now parses the ``<provider>/<model>`` slash shorthand
+        # (Pi ``resolveModelFromCli`` main.ts:303-304) and enriches from the
+        # catalog, so ``model.provider`` is populated for every pi-valid
+        # invocation (``--provider x --model y``, ``--model x/y``, or the
+        # OpenRouter-from-env path). This guard now fires only when NO model
+        # resolves at all — an empty/unknown provider — matching pi.
         if not model.provider:
             print(
                 "Error: --api-key requires a model to be specified via "

--- a/packages/aelix-coding-agent/src/aelix_coding_agent/cli/runtime_bootstrap.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/cli/runtime_bootstrap.py
@@ -90,7 +90,15 @@ def register_providers() -> None:
 
 
 def resolve_model(model_flag: str | None, provider_flag: str | None) -> Model:
-    """Resolve the turn :class:`Model` from flags + env (OpenRouter-aware)."""
+    """Resolve the turn :class:`Model` from flags + env.
+
+    Three paths: (1) OpenRouter-from-env (``OPENROUTER_API_KEY`` + a model id,
+    no conflicting ``--provider``); (2) explicit ``--provider``/``--model`` or
+    the ``<provider>/<model>`` slash shorthand, enriched from the Pi catalog so
+    the resolved model carries its real ``api`` (never the bare ``"unknown"``);
+    (3) a bare fallback model for an empty/unknown provider, which the caller's
+    guard turns into a graceful "No model selected" message.
+    """
 
     openrouter_key = os.environ.get("OPENROUTER_API_KEY")
     model_id = model_flag or os.environ.get("OPENROUTER_DEFAULT_MODEL")
@@ -116,9 +124,45 @@ def resolve_model(model_flag: str | None, provider_flag: str | None) -> Model:
             api=OPENAI_COMPLETIONS_API,
             base_url=env_base_url or _DEFAULT_OPENROUTER_BASE_URL,
         )
-    # Existing behavior: a bare model from explicit flags (the adapter resolves
-    # the per-provider key from env when the api is registered).
-    return Model(id=model_flag or "", provider=provider_flag or "")
+    # Explicit --provider/--model path. Two enrichments over the old bare
+    # ``Model(id, provider)`` return, which left ``api="unknown"`` (streaming.py
+    # Model default) and so made the stream loop raise the internal
+    # ``No provider registered for api='unknown'. Sprint 6a ... register_all()``
+    # error for the documented flagship commands (e.g.
+    # ``aelix --provider anthropic --model claude-sonnet-4-6 -p hi``):
+    #
+    #  1. ``<provider>/<model>`` slash shorthand — split it when no separate
+    #     ``--provider`` was given (Pi ``resolveModelFromCli`` main.ts:303-304),
+    #     so ``aelix --model openai/gpt-4o-mini`` resolves ``provider=openai``
+    #     instead of falling through with an empty provider ("No model selected").
+    #     Guarded by the OpenRouter branch above: with an ``OPENROUTER_API_KEY``
+    #     set, ``openai/gpt-4o-mini`` is (correctly) an OpenRouter model id and
+    #     never reaches here.
+    #  2. Catalog enrichment — resolve the full Pi catalog entry (carrying the
+    #     real ``api``, context window, cost, thinking map). For an id absent
+    #     from the catalog but under a known provider, backfill just ``api`` from
+    #     a sibling catalog model so a custom / newly-released id still resolves
+    #     an adapter instead of raising the "unknown" error. Providers whose
+    #     models span multiple apis (e.g. github-copilot) get the first sibling's
+    #     api — best-effort for the uncatalogued-id case; catalogued ids are
+    #     always exact.
+    provider = provider_flag or ""
+    resolved_id = model_flag or ""
+    if not provider and "/" in resolved_id:
+        provider, _, resolved_id = resolved_id.partition("/")
+    if provider and resolved_id:
+        from aelix_ai.models import get_model, get_models
+
+        catalog = get_model(provider, resolved_id)
+        if catalog is not None:
+            return catalog
+        siblings = get_models(provider)
+        if siblings:
+            return Model(id=resolved_id, provider=provider, api=siblings[0].api)
+    # Unknown provider (or empty flags): a bare model. The entry-point guard
+    # (``not model.provider`` / ``has_configured_auth``) turns this into a
+    # graceful "No model selected" / "No API key" message rather than a turn.
+    return Model(id=resolved_id, provider=provider)
 
 
 __all__ = ["load_dotenv", "register_providers", "resolve_model"]

--- a/tests/cli/test_runtime_bootstrap.py
+++ b/tests/cli/test_runtime_bootstrap.py
@@ -51,6 +51,68 @@ def test_resolve_model_key_without_model_is_bare(monkeypatch: pytest.MonkeyPatch
     assert m.provider == ""
 
 
+# --- Explicit --provider/--model path: catalog enrichment + slash shorthand ---
+# (regression: the bare return left api="unknown", so the documented
+# ``aelix --provider anthropic --model claude-sonnet-4-6 -p hi`` raised the
+# internal "No provider registered for api='unknown'. Sprint 6a ..." error.)
+
+
+def test_resolve_model_explicit_provider_model_enriched_from_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aelix_ai.models import get_model
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_DEFAULT_MODEL", raising=False)
+    m = resolve_model("claude-sonnet-4-6", "anthropic")
+    assert m == get_model("anthropic", "claude-sonnet-4-6")
+    assert m.api == "anthropic-messages"  # NOT the bare "unknown"
+
+
+def test_resolve_model_slash_shorthand_splits_and_enriches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aelix_ai.models import get_model
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_DEFAULT_MODEL", raising=False)
+    m = resolve_model("openai/gpt-4o-mini", None)  # <provider>/<model>, no --provider
+    assert m.provider == "openai" and m.id == "gpt-4o-mini"
+    assert m.api == get_model("openai", "gpt-4o-mini").api  # type: ignore[union-attr]
+
+
+def test_resolve_model_openrouter_key_keeps_slash_form_as_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With an OpenRouter key, ``openai/gpt-4o-mini`` is a valid OpenRouter model
+    # id and must NOT be split into the ``openai`` provider.
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENROUTER_DEFAULT_MODEL", raising=False)
+    m = resolve_model("openai/gpt-4o-mini", None)
+    assert m.provider == "openrouter"
+
+
+def test_resolve_model_unknown_id_known_provider_backfills_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aelix_ai.models import get_models
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_DEFAULT_MODEL", raising=False)
+    m = resolve_model("my-unreleased-model", "anthropic")  # id absent from catalog
+    assert m.provider == "anthropic" and m.id == "my-unreleased-model"
+    assert m.api == get_models("anthropic")[0].api and m.api != "unknown"
+
+
+def test_resolve_model_unknown_provider_is_bare(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Truly-unknown provider → bare model. The entry-point guard turns this into
+    # a graceful "No API key" message rather than the internal adapter error.
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_DEFAULT_MODEL", raising=False)
+    m = resolve_model("some-model", "no-such-provider")
+    assert m.provider == "no-such-provider" and m.api == "unknown"
+
+
 def test_load_dotenv_sets_new_keys(tmp_path) -> None:
     envfile = tmp_path / ".env"
     envfile.write_text('AELIX_TEST_K=hello\n# comment\nAELIX_TEST_Q="quoted"\n\nbadline\n')


### PR DESCRIPTION
Closes #71.

Fixes the single confirmed v0.1.0 release blocker: non-interactive `--print`/`--json` model selection failed for the flagship providers (Anthropic/OpenAI) and leaked internal developer language (`No provider registered for api='unknown'. Sprint 6a … register_all()`).

## Root cause
`resolve_model` backfilled `Model.api` from the catalog only on the OpenRouter-env branch; the explicit `--provider/--model` path left `api="unknown"`, and the `<provider>/<model>` slash shorthand was unparsed.

## Fix (scoped to avoid a concurrent-session conflict)
- Split the `<provider>/<model>` slash shorthand when no `--provider` (pi `resolveModelFromCli`); OpenRouter-env branch still wins first.
- Enrich from the Pi catalog (`get_model`); backfill `api` from a sibling for an uncatalogued id under a known provider.
- Scope: `cli/runtime_bootstrap.py` + `cli/entry.py` only. The third symptom (typed `/model <id>` in `tui/commands.py`) is **deferred** — that file is being edited in another session; follow-up.

## Verification
- E2E print smoke now reaches the provider (Anthropic/OpenAI **401** on a bogus key) instead of the internal error.
- +5 regression tests in `tests/cli/test_runtime_bootstrap.py` (13 pass); existing resolve_model / session-flag / scoped-model suites green (99 pass); ruff clean.

⚠️ Do not merge until the concurrent TUI branch on `main` has landed (working-tree/history coordination). Branched off the clean committed HEAD f75abe8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)