### PR TITLE
fix(coding-agent): wire `extension sign --kind catalog` (#88)

### DIFF
--- a/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_install.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_install.py
@@ -2053,7 +2053,7 @@ def _cmd_sign(args: list[str]) -> int:
         if a in ("-h", "--help"):
             print(
                 "usage: aelix extension sign <artifact> --key <keyId|pem-path> "
-                "[--name N] [--version V] [--kind path|pypi] [--passphrase] [--out FILE]"
+                "[--name N] [--version V] [--kind path|pypi|catalog] [--passphrase] [--out FILE]"
             )
             return 0
         if a == "--passphrase":
@@ -2095,8 +2095,8 @@ def _cmd_sign(args: list[str]) -> int:
     if key_ref is None:
         print("Error: sign requires --key <keyId|pem-path>.", file=sys.stderr)
         return _EXIT_DIDNT_RUN
-    if kind not in ("path", "pypi"):
-        print("Error: --kind must be 'path' or 'pypi'.", file=sys.stderr)
+    if kind not in ("path", "pypi", "catalog"):
+        print("Error: --kind must be 'path', 'pypi', or 'catalog'.", file=sys.stderr)
         return _EXIT_DIDNT_RUN
 
     key_path = _resolve_key_path(key_ref)
@@ -2113,10 +2113,28 @@ def _cmd_sign(args: list[str]) -> int:
 
     try:
         priv = extension_signing.load_private_key(key_path, passphrase=passphrase)
-        sidecar, key_id = extension_signing.sign_artifact(
-            art, priv, kind=kind, name=name, version=version,
-            out=Path(out).expanduser() if out else None,
-        )
+        if kind == "catalog":
+            # A catalog document (catalog.json) is signed over its RAW bytes with a
+            # kind="catalog" statement — the exact form verify_signed_document expects
+            # (sign_artifact would stamp kind="path" and the catalog verifier would
+            # reject it on a statement mismatch).
+            import json
+
+            sidecar_bytes = extension_signing.sign_document(
+                art.read_bytes(), priv, kind="catalog", name=name, version=version
+            )
+            sidecar = (
+                Path(out).expanduser()
+                if out
+                else art.with_name(art.name + extension_signing.AELIXSIG_SUFFIX)
+            )
+            sidecar.write_bytes(sidecar_bytes)
+            key_id = str(json.loads(sidecar_bytes.decode("utf-8")).get("keyId", "?"))
+        else:
+            sidecar, key_id = extension_signing.sign_artifact(
+                art, priv, kind=kind, name=name, version=version,
+                out=Path(out).expanduser() if out else None,
+            )
     except extension_signing.CryptoUnavailable as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return _EXIT_DIDNT_RUN

--- a/tests/cli/test_extension_signing.py
+++ b/tests/cli/test_extension_signing.py
@@ -24,6 +24,7 @@ from aelix_ai.settings import ExtensionSourceObject, SettingsManager
 from aelix_coding_agent.cli import extension_pins as ep
 from aelix_coding_agent.cli import extension_signing as es
 from aelix_coding_agent.cli.extension_install import (
+    _cmd_sign,
     install_extension,
     run_extension_command,
     run_extension_command_async,
@@ -917,3 +918,93 @@ def test_verify_document_first_party_and_revoked(
     )
     with pytest.raises(ep.VerifyRefusal):
         _verify_doc(tmp_path, _DOC, sidecar, require_signature=True)
+
+
+# === Issue #88: `sign --kind catalog` ↔ catalog verifier round-trip ==========
+#
+# The catalog verifier (`_make_catalog_verifier` → verify_signed_document, kind='catalog')
+# demands a kind='catalog' statement. Before #88 the `sign` verb only did path|pypi, so a
+# catalog signed as kind='path' was REFUSED on a statement mismatch. These drive the new
+# `_cmd_sign` catalog branch straight through the real catalog verifier via `_verify_doc`.
+
+_CATALOG = _DOC  # a catalog.json document (`{"catalog":[…]}`) reused as the signed bytes
+
+
+def test_cmd_sign_catalog_round_trip_authenticates(tmp_path: Path) -> None:
+    # e2e: `sign --kind catalog` writes a kind='catalog' envelope over the RAW catalog
+    # bytes that the catalog verifier accepts once the signer is trusted.
+    key_id, pub_b64, pem = _make_key(tmp_path)
+    catalog = tmp_path / "catalog.json"
+    catalog.write_bytes(_CATALOG)
+    rc = _cmd_sign([str(catalog), "--key", str(pem), "--kind", "catalog"])
+    assert rc == 0
+    sidecar_path = catalog.with_name(catalog.name + es.AELIXSIG_SUFFIX)
+    assert sidecar_path.is_file()  # sibling catalog.json.aelixsig
+    _trust(tmp_path, key_id, pub_b64)
+    out = _verify_doc(tmp_path, catalog.read_bytes(), sidecar_path.read_bytes())
+    assert out.authenticated and out.key_id == key_id and out.sig and out.statement_json
+    st = json.loads(out.statement_json)
+    assert st["kind"] == "catalog"
+    assert st["sha256"] == hashlib.sha256(catalog.read_bytes()).hexdigest()
+
+
+def test_cmd_sign_catalog_tamper_refuses(tmp_path: Path) -> None:
+    # Appending a byte to the catalog after signing → the digest no longer matches the
+    # signed statement → the (trusted-key) verify refuses even on the default path.
+    key_id, pub_b64, pem = _make_key(tmp_path)
+    _trust(tmp_path, key_id, pub_b64)
+    catalog = tmp_path / "catalog.json"
+    catalog.write_bytes(_CATALOG)
+    assert _cmd_sign([str(catalog), "--key", str(pem), "--kind", "catalog"]) == 0
+    sidecar = catalog.with_name(catalog.name + es.AELIXSIG_SUFFIX).read_bytes()
+    tampered = _CATALOG + b" "  # one appended byte → a different sha256
+    with pytest.raises(ep.VerifyRefusal, match="statement mismatch"):
+        _verify_doc(tmp_path, tampered, sidecar)
+
+
+def test_cmd_sign_kind_path_catalog_verify_refuses(tmp_path: Path) -> None:
+    # REGRESSION guard — documents exactly why kind='catalog' is required. Signing the
+    # SAME catalog with `--kind path` routes to sign_artifact, which stamps kind='path';
+    # catalog-verifying it (kind='catalog') is refused on the kind cross-check. This is the
+    # statement mismatch #88 closes by adding the kind='catalog' sign path.
+    key_id, pub_b64, pem = _make_key(tmp_path)
+    _trust(tmp_path, key_id, pub_b64)
+    catalog = tmp_path / "catalog.json"
+    catalog.write_bytes(_CATALOG)
+    rc = _cmd_sign([str(catalog), "--key", str(pem), "--kind", "path"])
+    assert rc == 0
+    sidecar = catalog.with_name(catalog.name + es.AELIXSIG_SUFFIX).read_bytes()
+    with pytest.raises(ep.VerifyRefusal, match="statement mismatch"):
+        _verify_doc(tmp_path, catalog.read_bytes(), sidecar)  # default kind='catalog'
+
+
+def test_cmd_sign_catalog_out_path_honored(tmp_path: Path) -> None:
+    # A custom --out path receives the envelope (no sibling sidecar is written), and it
+    # verifies just like the default location.
+    key_id, pub_b64, pem = _make_key(tmp_path)
+    _trust(tmp_path, key_id, pub_b64)
+    catalog = tmp_path / "catalog.json"
+    catalog.write_bytes(_CATALOG)
+    out = tmp_path / "detached" / "catalog.aelixsig"
+    out.parent.mkdir()
+    rc = _cmd_sign(
+        [str(catalog), "--key", str(pem), "--kind", "catalog", "--out", str(out)]
+    )
+    assert rc == 0
+    assert out.is_file()
+    assert not catalog.with_name(catalog.name + es.AELIXSIG_SUFFIX).exists()  # no sibling
+    result = _verify_doc(tmp_path, catalog.read_bytes(), out.read_bytes())
+    assert result.authenticated and result.key_id == key_id
+
+
+def test_cmd_sign_rejects_unknown_kind(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The kind validation now names 'catalog' too: an unknown kind is rejected (exit 2)
+    # with the updated message.
+    _, _, pem = _make_key(tmp_path)
+    catalog = tmp_path / "catalog.json"
+    catalog.write_bytes(_CATALOG)
+    rc = _cmd_sign([str(catalog), "--key", str(pem), "--kind", "bogus"])
+    assert rc == 2
+    assert "must be 'path', 'pypi', or 'catalog'" in capsys.readouterr().err


### PR DESCRIPTION
Closes #88. Adds the missing CLI path to sign a catalog document so aelix's catalog verifier accepts it.

**Gap:** `_make_catalog_verifier` → `verify_signed_document(kind="catalog")` requires a `kind="catalog"` statement, but `extension sign` only accepted `path|pypi`. A catalog signed as `kind=path` was rejected on a statement mismatch → no way to sign the official `catalog.json`. (The aelix-marketplace docs even instructed the failing command — fixed in a companion commit there.)

**Fix:** `extension sign <catalog> --key <keyId> --kind catalog` → routes to `sign_document(kind="catalog")`, writes `<artifact>.aelixsig`. `path`/`pypi` unchanged.

**Tests (+5):** sign→`verify_signed_document` authenticates (statement kind=catalog, matching sha256); one-byte tamper → `VerifyRefusal`; **regression guard** — the same catalog signed `--kind path` is refused by the catalog verifier (documents the exact gap); `--out` honored; invalid-kind rejected.

**Verify:** adversarial e2e round-trip (keygen→trust→sign→verify) authenticates + tamper refuses; 66 signing tests + 181 install/discover green; whole-repo ruff clean. Beta stays dormant (`FIRST_PARTY_KEYS` empty); this unblocks #76 Phase 3 (catalog signing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)