### PR TITLE
feat(coding-agent): activate default marketplace catalog + progressive signature hardening (#89)

### DIFF
--- a/docs/decisions/0192-issue76-default-catalog-opt-out.md
+++ b/docs/decisions/0192-issue76-default-catalog-opt-out.md
@@ -2,7 +2,22 @@
 
 - **Status:** Accepted (2026-07-10) — scheme owner-confirmed (Run 2). Design record;
   lands with the #76 beta implementation, precedes the code and seeds it (same pattern
-  as ADR-0186/0187/0188/0189).
+  as ADR-0186/0187/0188/0189). **Amended 2026-07-12 (#89) — see Amendment below.**
+- **Amendment (2026-07-12, #89) — progressive hardening + default catalog activated:**
+  guard ⑤ originally made the official/default catalog signature-required the moment
+  `DEFAULT_CATALOG_URL` became non-empty (fail-closed on any set URL). That was *stricter*
+  than #67 per-extension signing (opt-in, warn-default until a trusted key is present) and,
+  because the catalog is strictly **advisory** (the real execution-trust boundary is the
+  install-time consent prompt + `verify_and_pin` — re-confirmed against upstream pi, which
+  has **zero** signing/pinning of any kind), the fail-closed-on-set-URL rule blocked
+  activating the marketplace at all until a first-party key was provisioned. **Refinement:**
+  the default catalog is signature-required **only once a first-party trust anchor exists**
+  (`FIRST_PARTY_KEYS` non-empty); until then it is admitted best-effort over TLS (a
+  present-but-**invalid** trusted signature still refuses), auto-upgrading to fail-closed
+  the moment the maintainer commits the key. This harmonizes the catalog layer with #67.
+  `DEFAULT_CATALOG_URL` is now set to the GitHub Pages catalog
+  (`https://handochan.github.io/aelix-marketplace/catalog.json`) and stays opt-out
+  (`AELIX_DEFAULT_CATALOG=""` / `--no-default-catalog` / `source remove`).
 - **Date:** 2026-07-10
 - **Sprint:** #76 first public release = **beta**. Run 1 was recon; this is Run 2
   (design). Two coupled tracks: **(A)** a `curl | sh` + GitHub Releases beta channel

--- a/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_catalog.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_catalog.py
@@ -94,13 +94,17 @@ GIT_CLONE_TIMEOUT = 60.0
 
 #: Env var that OVERRIDES / repoints the built-in default catalog URL for one run.
 DEFAULT_CATALOG_ENV = "AELIX_DEFAULT_CATALOG"
-#: The built-in default catalog URL. EMPTY in beta = **dormant** (no first-party
-#: catalog infra ships yet — mirrors the empty ``FIRST_PARTY_KEYS`` "mechanism-only"
-#: posture). This is the lowest-priority fallback of the ``AELIX_DEFAULT_CATALOG``
-#: override chain, NOT a hardcoded literal — an enterprise repoints it via the env
-#: var and an empty value keeps the default absent (guard ②). Resolved by
+#: The built-in default catalog URL — the official aelix marketplace catalog on
+#: GitHub Pages. ADVISORY (chooses only WHAT to browse; every install still gates on
+#: consent + verify_and_pin). Signature enforcement is PROGRESSIVE (guard ⑤,
+#: ADR-0192 §amendment): while ``FIRST_PARTY_KEYS`` is empty this catalog is admitted
+#: best-effort over TLS (a present-but-INVALID trusted signature still refuses); once
+#: the maintainer provisions the first-party catalog key it auto-upgrades to
+#: fail-closed. This is the lowest-priority fallback of the ``AELIX_DEFAULT_CATALOG``
+#: override chain, NOT a frozen literal — an enterprise repoints it via the env var and
+#: an empty value keeps the default absent (guard ②). Resolved by
 #: :func:`resolve_default_catalog_url`.
-DEFAULT_CATALOG_URL = ""
+DEFAULT_CATALOG_URL = "https://handochan.github.io/aelix-marketplace/catalog.json"
 #: Suffix of the detached-signature sidecar fetched beside a catalog document
 #: (``<location>.aelixsig``) and handed to an injected :data:`DocumentVerifier`.
 SIDECAR_SUFFIX = ".aelixsig"

--- a/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_install.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_install.py
@@ -1789,13 +1789,20 @@ async def _cmd_discover(
                     fetch_locations.append(loc)
                 else:
                     print(f"  ⓘ skipped {loc}: offline (network transport)")
-        # Guard ⑤: the official / default catalog is signature-required (dormant in
-        # beta — the default URL + FIRST_PARTY_KEYS are both empty). The verifier
-        # gates each catalog's raw bytes before parse/cache; a refusal degrades only
-        # that catalog to an error row.
+        # Guard ⑤ (progressive hardening, ADR-0192 §amendment): the official / default
+        # catalog is signature-required ONLY once a first-party trust anchor exists to
+        # verify it (FIRST_PARTY_KEYS non-empty) — consistent with #67 per-extension
+        # signing, which is warn-default until a trusted key is present. Before the
+        # maintainer provisions the first-party catalog key the default stays
+        # advisory-over-TLS (best-effort: an unsigned/untrusted default is admitted, a
+        # present-but-INVALID trusted signature still refuses); committing the key
+        # auto-upgrades it to fail-closed. The verifier gates each catalog's raw bytes
+        # before parse/cache; a refusal degrades only that catalog to an error row.
         default_id = _effective_default_identity()
         signature_required = (
-            frozenset({default_id}) if default_id is not None else frozenset()
+            frozenset({default_id})
+            if (default_id is not None and extension_signing.FIRST_PARTY_KEYS)
+            else frozenset()
         )
         verifier = _make_catalog_verifier(
             agent_dir, signature_required=signature_required

--- a/tests/cli/test_extension_catalog.py
+++ b/tests/cli/test_extension_catalog.py
@@ -652,11 +652,25 @@ def test_fetch_git_symlink_catalog_refused(tmp_path: Path) -> None:
 # =====================================================================
 
 
-def test_resolve_default_catalog_env_unset_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Beta: env unset + empty ``DEFAULT_CATALOG_URL`` placeholder → dormant (None)."""
+def test_resolve_default_catalog_env_unset_is_pages_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Beta ACTIVATION: the built-in default now ships as the official GitHub Pages
+    marketplace catalog (no longer the dormant empty placeholder), so env-unset resolves
+    to it. The explicit opt-out is an EMPTY env value, which restores the dormant
+    ``None`` (guard ②).
+    """
 
+    # The shipped placeholder is activated: a non-empty HTTPS default URL.
+    assert ec.DEFAULT_CATALOG_URL  # non-empty: the official default is ACTIVE in beta
+    assert ec.DEFAULT_CATALOG_URL.startswith("https://")
+
+    # env unset → the activated Pages default (NOT None).
     monkeypatch.delenv(ec.DEFAULT_CATALOG_ENV, raising=False)
-    assert ec.DEFAULT_CATALOG_URL == ""  # placeholder ships empty in beta
+    assert ec.resolve_default_catalog_url() == ec.DEFAULT_CATALOG_URL
+
+    # env="" → explicit opt-out → back to dormant None (the env-driven kill switch).
+    monkeypatch.setenv(ec.DEFAULT_CATALOG_ENV, "")
     assert ec.resolve_default_catalog_url() is None
 
 

--- a/tests/cli/test_extension_discover.py
+++ b/tests/cli/test_extension_discover.py
@@ -178,8 +178,12 @@ def test_discover_refresh_fetches_and_writes_cache(
 
 
 def test_discover_no_catalog_registered_empty_state(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # The built-in default is ACTIVE by default now, so the genuine "no catalog" state is
+    # reached by OPTING OUT (AELIX_DEFAULT_CATALOG="") with no stored sources → the
+    # effective catalog list is empty → the honest "No catalog registered" message.
+    monkeypatch.setenv("AELIX_DEFAULT_CATALOG", "")
     code = run_extension_command(["discover"], settings=_mem_settings())
     assert code == 0
     assert "No catalog registered" in capsys.readouterr().out
@@ -261,8 +265,12 @@ def test_discover_query_no_match(
 
 
 def test_search_is_discover_alias(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # ``search`` dispatches to the discover handler → the SAME empty-state message. Opt
+    # out of the now-active built-in default (AELIX_DEFAULT_CATALOG="") so the
+    # no-catalog branch is reached deterministically for the alias check.
+    monkeypatch.setenv("AELIX_DEFAULT_CATALOG", "")
     code = run_extension_command(["search"], settings=_mem_settings())
     assert code == 0
     assert "No catalog registered" in capsys.readouterr().out
@@ -762,12 +770,13 @@ def test_catalog_identity_normalizes_git_forms() -> None:
     assert _catalog_identity("git+https://h/r.git") == "git+https://h/r.git"
 
 
-def test_effective_locations_no_default_when_dormant(
+def test_effective_locations_no_default_when_opted_out(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Beta placeholder empty + env unset → no built-in default (dormant): the
+    # The built-in default is ACTIVE by default, so "no built-in default" is the OPT-OUT
+    # path: an explicitly-empty AELIX_DEFAULT_CATALOG kills it for this run → the
     # effective list is exactly the stored catalogs.
-    monkeypatch.delenv("AELIX_DEFAULT_CATALOG", raising=False)
+    monkeypatch.setenv("AELIX_DEFAULT_CATALOG", "")
     assert _effective_default_identity() is None
     mem = SettingsManager.in_memory(
         {"extensionSources": [{"spec": "file:///corp/c.json", "kind": "catalog"}]}
@@ -1090,20 +1099,117 @@ def test_catalog_verifier_requires_signature_only_for_default(tmp_path: Path) ->
 async def test_default_catalog_is_signature_required_end_to_end(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # Guard ⑤ live end-to-end: with a default configured (a file:// URL so no network
-    # is touched), an UNSIGNED default catalog degrades to an error row and a
-    # refresh where it is the only catalog exits 2. Dormant in beta ONLY because the
-    # shipped default URL is empty — the mechanism itself is wired.
+    # Guard ⑤ PROGRESSIVE HARDENING (ADR-0192 §amendment) live end-to-end. A file:// default
+    # (no network) is UNSIGNED; whether it MUST carry a signature is gated on a first-party
+    # trust anchor existing to verify it:
+    #   (a) FIRST_PARTY_KEYS EMPTY (beta ship state) → admitted best-effort over TLS/transport;
+    #   (b) FIRST_PARTY_KEYS NON-EMPTY (a key is provisioned) → fail-closed: the unsigned
+    #       default degrades to an error row and, being the only catalog, the refresh exits 2.
+    from aelix_coding_agent.cli import extension_signing as es
+
     file_default = _write_catalog(
         tmp_path / "official.json",
         [{"name": "o", "source": "o-pkg"}],
         name="official",
     )
     monkeypatch.setenv("AELIX_DEFAULT_CATALOG", file_default)
-    mem = _mem_settings()
-    code = await run_extension_command_async(["discover", "--refresh"], settings=mem)
+
+    # (a) No first-party anchor yet → the unsigned default is ADMITTED (discover succeeds,
+    # the entry lists, and NOTHING refuses on the signature channel).
+    assert not es.FIRST_PARTY_KEYS  # beta ships with no first-party catalog key
+    code = await run_extension_command_async(
+        ["discover", "--refresh"], settings=_mem_settings()
+    )
+    assert code == 0
+    admitted = capsys.readouterr()
+    assert "catalog: official" in admitted.out  # the unsigned default's entry rendered
+    assert "signature" not in admitted.err.lower()
+
+    # (b) Provision a first-party trust anchor → the SAME unsigned default is now REFUSED
+    # (fail-closed): a refresh where it is the only catalog exits 2 with a signature error.
+    monkeypatch.setattr(es, "FIRST_PARTY_KEYS", {"fake": es._b64e(b"\x00" * 32)})
+    code = await run_extension_command_async(
+        ["discover", "--refresh"], settings=_mem_settings()
+    )
     assert code == 2
     assert "signature" in capsys.readouterr().err.lower()
+
+
+async def test_default_catalog_invalid_trusted_signature_refuses_regardless(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Guard ⑤ fail-closed FLOOR (preserved under progressive hardening): a default catalog
+    # carrying a signature by a TRUSTED key whose signature does NOT verify is REFUSED
+    # ALWAYS — even in beta with FIRST_PARTY_KEYS EMPTY (the best-effort path). Tampering
+    # evidence never degrades to "admitted". file:// default → deterministic, no network.
+    from aelix_coding_agent.cli import extension_signing as es
+
+    agent_dir = str(_agent_dir(tmp_path))
+    official = tmp_path / "official.json"
+    file_default = _write_catalog(
+        official, [{"name": "o", "source": "o-pkg"}], name="official"
+    )
+    monkeypatch.setenv("AELIX_DEFAULT_CATALOG", file_default)
+
+    # Sign the EXACT on-disk bytes with a TRUSTED key, then corrupt the signature so the
+    # trusted key's signature FAILS to verify (well-formed but wrong).
+    key_id, pub_b64, pem = es.keygen(agent_dir)
+    keys_path = es.trusted_keys_path(agent_dir)
+    store = es.load_trusted_keys(keys_path)
+    keys = dict(store.keys)
+    keys[key_id] = es.TrustedKey(
+        key_id=key_id, public_key=pub_b64, label=None, added_at=ep.now_iso()
+    )
+    es.save_trusted_keys(es.TrustStore(keys=keys, revoked=store.revoked), keys_path)
+    sidecar = es.sign_document(
+        official.read_bytes(), es.load_private_key(pem), kind="catalog"
+    )
+    env = json.loads(sidecar)
+    env["sig"] = es._b64e(b"\x00" * 64)  # a wrong (but well-formed) signature
+    (tmp_path / "official.json.aelixsig").write_bytes(json.dumps(env).encode("utf-8"))
+
+    # FIRST_PARTY_KEYS empty (beta) → the progressive gate does NOT require a signature;
+    # yet a trusted-key signature that fails verification refuses REGARDLESS (exit 2).
+    assert not es.FIRST_PARTY_KEYS
+    code = await run_extension_command_async(
+        ["discover", "--refresh"], settings=_mem_settings()
+    )
+    assert code == 2
+    assert "signature" in capsys.readouterr().err.lower()
+
+
+async def test_default_catalog_valid_first_party_signature_admitted_under_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Positive fail-closed path: once a first-party anchor exists (require ON for the
+    # default), a default catalog carrying a VALID signature by that first-party key
+    # AUTHENTICATES and is admitted (exit 0). Proves the hardened gate is a signature
+    # CHECK, not a blanket block on the default.
+    from aelix_coding_agent.cli import extension_signing as es
+
+    agent_dir = str(_agent_dir(tmp_path))
+    official = tmp_path / "official.json"
+    file_default = _write_catalog(
+        official, [{"name": "o", "source": "o-pkg"}], name="official"
+    )
+    monkeypatch.setenv("AELIX_DEFAULT_CATALOG", file_default)
+
+    key_id, pub_b64, pem = es.keygen(agent_dir)
+    sidecar = es.sign_document(
+        official.read_bytes(), es.load_private_key(pem), kind="catalog"
+    )
+    (tmp_path / "official.json.aelixsig").write_bytes(sidecar)
+    # The signer IS the first-party anchor → require is ON for the default AND the key is
+    # trusted, so the valid signature authenticates.
+    monkeypatch.setattr(es, "FIRST_PARTY_KEYS", {key_id: pub_b64})
+
+    code = await run_extension_command_async(
+        ["discover", "--refresh"], settings=_mem_settings()
+    )
+    assert code == 0
+    out = capsys.readouterr()
+    assert "catalog: official" in out.out
+    assert "signature" not in out.err.lower()
 
 
 async def test_discover_no_default_catalog_flag_is_ephemeral(

--- a/tests/tui/test_p0_consumer_batch.py
+++ b/tests/tui/test_p0_consumer_batch.py
@@ -268,9 +268,12 @@ async def test_footer_shows_real_mode_and_context_label() -> None:
             mode_provider=lambda: "all",
             mode="default",
         )
-        # mode_provider ("all") wins over the local "default" placeholder
+        # mode_provider ("all") wins over the local "default" placeholder.
+        # Assert on the mode SEGMENT (rendered "⏵⏵ <mode>"), not the whole footer
+        # line, which also carries the live git branch (⎇ <branch>) — a bare
+        # "default" substring check false-fails on any branch named "…default…".
         assert "⏵⏵ all" in chrome._footer_line
-        assert "default" not in chrome._footer_line
+        assert "⏵⏵ default" not in chrome._footer_line
         # live context meter segment appears after a turn
         ctx.set_context_label("◔ 5%")
         assert "◔ 5%" in chrome._footer_line


### PR DESCRIPTION
Closes #89 (#76 Phase 2). Activates the official default marketplace catalog and harmonizes its signature enforcement with the rest of the signing stack.

**Change**
- `DEFAULT_CATALOG_URL` → `https://handochan.github.io/aelix-marketplace/catalog.json` (was empty/dormant). Still **opt-out** (`AELIX_DEFAULT_CATALOG=""` / `--no-default-catalog` / `source remove`).
- **Guard ⑤ → progressive hardening:** the default catalog is signature-required **only once a first-party trust anchor exists** (`FIRST_PARTY_KEYS` non-empty), not the moment the URL is set.

**Why** (verified against the code + upstream pi): the catalog is strictly *advisory* — the real execution-trust boundary is the install-time consent prompt + `verify_and_pin`. Upstream **pi has zero signing/pinning** of any kind, so signing is an aelix-original differentiator. The old "fail-closed on any set URL" was *stricter* than #67 per-extension signing (opt-in / warn-default) and blocked activating the marketplace before a key was provisioned. Now: unsigned default admitted best-effort over TLS while `FIRST_PARTY_KEYS` is empty (a present-but-**invalid** trusted signature still refuses); committing the first-party key **auto-upgrades to fail-closed**.

**Tests** — invariants RE-EXPRESSED, not deleted (adversarially audited): the fail-closed `exit 2 + signature error` assertion now fires under the `FIRST_PARTY_KEYS`-non-empty branch; +2 new tests (invalid-trusted-sig refuses regardless of the gate; valid first-party signature admitted under require). **Full suite 5228 passed / 1 skipped; whole-repo ruff clean; e2e both directions confirmed.** ADR-0192 amended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)