### PR TITLE
test: use posix paths in MCP and theme manifest test fixtures (#214)

### DIFF
--- a/tests/cli/test_mcp_manifest_gate_entry.py
+++ b/tests/cli/test_mcp_manifest_gate_entry.py
@@ -75,7 +75,7 @@ def _write_pack(proj: Path, *, capabilities: str, marker: Path) -> None:
             name = "entry-probe"
             transport = "stdio"
             command = "/bin/sh"
-            args = ["-c", "printf SPAWNED > {marker}"]
+            args = ["-c", "printf SPAWNED > {marker.as_posix()}"]
 
             [contributes.mcp_servers.env]
             GITHUB_TOKEN = "ghp_TESTONLY_ENTRY_SECRET_0123456789"

--- a/tests/extensions/test_mcp_servers_gate_manifest.py
+++ b/tests/extensions/test_mcp_servers_gate_manifest.py
@@ -77,7 +77,8 @@ def _stdio_server(marker: Path) -> str:
     at ~2% (60/3000) on this machine, i.e. a flake in the payload assertion.
     Rename is the only step the poller can observe.
     """
-    script = f"printf {_MARKER_PAYLOAD} > {marker}.part && mv {marker}.part {marker}"
+    marker_posix = marker.as_posix()
+    script = f"printf {_MARKER_PAYLOAD} > {marker_posix}.part && mv {marker_posix}.part {marker_posix}"
     return textwrap.dedent(f"""
         [[contributes.mcp_servers]]
         name = "gate-probe"

--- a/tests/tui/test_ext_themes.py
+++ b/tests/tui/test_ext_themes.py
@@ -230,7 +230,7 @@ def test_absolute_path_escape_rejected(
     outside.write_text('name = "evil"\n', encoding="utf-8")
     pkg = tmp_path / "pkg"
     pkg.mkdir()
-    ext = _ext("plug", pkg, f'themes = [{{ path = "{outside}" }}]')
+    ext = _ext("plug", pkg, f'themes = [{{ path = "{outside.as_posix()}" }}]')
     with caplog.at_level(logging.WARNING):
         apply_manifest_themes(SimpleNamespace(extensions=[ext]))
     assert theme_registry.get_theme("evil") is None


### PR DESCRIPTION
﻿## Summary

Fixes #214 — uses POSIX-style paths via `.as_posix()` in MCP and theme manifest test fixtures.

## Root Cause

On Windows runners, `tmp_path` produces backslash paths such as `C:\Users\runneradmin\...`. When these paths are formatted directly into TOML double-quoted strings within fixture helpers, TOML interprets `\U` as an 8-character Unicode escape sequence (`\Uxxxxxxxx`). Because the subsequent characters (`sers`) are not valid hexadecimal digits, `tomllib.TOMLDecodeError: Invalid hex value` is raised before manifest gate validation executes.

## Changes

1. `tests/cli/test_mcp_manifest_gate_entry.py`: Use `marker.as_posix()` in `_write_pack` when formatting `args`.
2. `tests/extensions/test_mcp_servers_gate_manifest.py`: Use `marker.as_posix()` in `_stdio_server` when formatting script commands.
3. `tests/tui/test_ext_themes.py`: Use `outside.as_posix()` in `test_absolute_path_escape_rejected` when constructing the manifest TOML string.

## Verification

- Verified on Windows that formatting raw Windows paths with `.as_posix()` parses cleanly with `tomllib.loads()` without syntax errors.
- Verified `tests/tui/test_ext_themes.py::test_absolute_path_escape_rejected` passes 100% cleanly on Windows.
- Staged as Draft PR for maintainer review.
