### PR TITLE
fix: contain timed-out subprocess descendants

### DIFF
--- a/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_catalog.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/cli/extension_catalog.py
@@ -51,6 +51,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
+from aelix_coding_agent.tools._process_tree import run_contained
+
 __all__ = [
     "CATALOG_CACHE_FILENAME",
     "DEFAULT_CATALOG_ENV",
@@ -469,7 +471,7 @@ def _default_opener(url: str, timeout: float) -> bytes:
 def _default_git_runner(argv: list[str]) -> subprocess.CompletedProcess[bytes]:
     # A wall-clock timeout so a hung remote surfaces as TimeoutExpired (translated
     # to a CatalogError in _git_clone_bytes) instead of blocking discover forever.
-    return subprocess.run(  # noqa: S603 — argv list, no shell
+    return run_contained(  # noqa: S603 — argv list, no shell
         argv, capture_output=True, check=False, timeout=GIT_CLONE_TIMEOUT
     )
 

--- a/packages/aelix-coding-agent/src/aelix_coding_agent/extensions/api.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/extensions/api.py
@@ -102,6 +102,8 @@ from aelix_agent_core.harness.hooks import (
 from aelix_agent_core.types import AgentTool
 from aelix_ai.streaming import Model, StreamFn
 
+from aelix_coding_agent.tools._process_tree import run_contained
+
 from .ext_ui import ExtensionUIContext
 from .headless_ui import HEADLESS_UI_CONTEXT
 
@@ -2043,7 +2045,7 @@ class ExtensionAPI:
         killed = False
         try:
             proc = await asyncio.to_thread(
-                subprocess.run,
+                run_contained,
                 [command, *args],
                 capture_output=True,
                 text=True,

--- a/packages/aelix-coding-agent/src/aelix_coding_agent/tools/_process_tree.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/tools/_process_tree.py
@@ -14,11 +14,12 @@ leader and ``proc.kill()`` would terminate it alone and orphan its descendants.
 ``taskkill /T /F`` walks the real parent/child tree, which is the property the
 POSIX ``killpg`` was there for.
 
-EXPERIMENTAL. The win32 arm now RUNS on the ``windows-latest`` leg — including
-the case that deletes ``os.killpg``, ``os.getpgid`` and ``signal.SIGKILL``, which
-is what proves the POSIX body is never reached there. ``taskkill`` itself is
-still stubbed in every case, so the shell-out has never been executed anywhere.
-See ``SLICE-STATUS.md``.
+The win32 arm runs on the ``windows-latest`` leg — including the case that
+deletes ``os.killpg``, ``os.getpgid`` and ``signal.SIGKILL``, which proves the
+POSIX body is never reached there. The contained-runner regression also
+exercises a real descendant holding an inherited stdout pipe, while the
+``taskkill`` invocation remains unit-tested with a stub. See
+``SLICE-STATUS.md``.
 """
 
 from __future__ import annotations
@@ -28,8 +29,96 @@ import os
 import signal
 import subprocess
 import sys
+from typing import Any
 
-__all__ = ["kill_process_tree"]
+__all__ = ["kill_process_tree", "run_contained"]
+
+
+# A descendant can inherit stdout/stderr from the direct child.  After the
+# direct child is killed, an unbounded ``communicate()`` can therefore wait for
+# that descendant's pipe handle forever.  Every timeout cleanup below is
+# explicitly bounded so a broken or partial containment mechanism cannot turn a
+# timeout into a hang.
+_REAP_TIMEOUT = 2.0
+
+
+def run_contained(
+    args: list[str],
+    *,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    capture_output: bool = False,
+    text: bool = False,
+    timeout: float | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[Any]:
+    """Run a command with process-tree containment and bounded timeout cleanup.
+
+    This is the synchronous counterpart to :func:`run_cancellable`.  It keeps
+    the ``subprocess.run``-compatible result and exception behaviour needed by
+    the synchronous extension catalog and TUI callers, while fixing the
+    Windows timeout trap: ``subprocess.run(timeout=...)`` kills only the direct
+    child and then performs an unbounded ``communicate()``.
+
+    ``start_new_session`` gives POSIX a private process group.  Windows ignores
+    that flag, so :func:`kill_process_tree` uses ``taskkill /T /F`` there.
+    ``TimeoutExpired`` is re-raised after the tree has been asked to die and
+    the direct child has had only a bounded reap window.
+    """
+
+    stdout_pipe = subprocess.PIPE if capture_output else None
+    stderr_pipe = subprocess.PIPE if capture_output else None
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        env=env,
+        stdout=stdout_pipe,
+        stderr=stderr_pipe,
+        text=text,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        # Cleanup must never mask the original timeout.  kill_process_tree is
+        # best-effort by contract; the suppress is also useful for unusual test
+        # doubles and stripped environments.
+        with contextlib.suppress(Exception):
+            kill_process_tree(proc.pid)
+
+        stdout = exc.output
+        stderr = exc.stderr
+        try:
+            reaped_stdout, reaped_stderr = proc.communicate(timeout=_REAP_TIMEOUT)
+        except subprocess.TimeoutExpired as reap_exc:
+            # A descendant may still own a pipe even after the tree kill was
+            # attempted.  Kill the direct child as a final bounded fallback,
+            # reap its exit status without touching the pipes, and close our
+            # handles so this function cannot wait indefinitely.
+            if reap_exc.output is not None:
+                stdout = reap_exc.output
+            if reap_exc.stderr is not None:
+                stderr = reap_exc.stderr
+            with contextlib.suppress(OSError):
+                proc.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+                proc.wait(timeout=_REAP_TIMEOUT)
+            for stream in (proc.stdout, proc.stderr):
+                if stream is not None:
+                    with contextlib.suppress(OSError):
+                        stream.close()
+        else:
+            stdout = reaped_stdout if reaped_stdout is not None else stdout
+            stderr = reaped_stderr if reaped_stderr is not None else stderr
+
+        raise subprocess.TimeoutExpired(
+            args, timeout if timeout is not None else 0.0, output=stdout, stderr=stderr
+        ) from exc
+
+    completed = subprocess.CompletedProcess(args, proc.returncode, stdout, stderr)
+    if check:
+        completed.check_returncode()
+    return completed
 
 
 def kill_process_tree(pid: int, *, platform: str | None = None) -> None:

--- a/packages/aelix-coding-agent/src/aelix_coding_agent/tui/completion.py
+++ b/packages/aelix-coding-agent/src/aelix_coding_agent/tui/completion.py
@@ -47,6 +47,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 from prompt_toolkit.completion import Completer, Completion
 
+from aelix_coding_agent.tools._process_tree import run_contained
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
 
@@ -247,7 +249,7 @@ def _fd_enumerate(fd_bin: str, base: Path) -> list[str] | None:
         argv += ["--exclude", excluded]
     argv += ["--max-results", str(_TREE_ENUM_CAP)]
     try:
-        proc = subprocess.run(  # noqa: S603 — fixed argv, no shell, no user input
+        proc = run_contained(  # noqa: S603 — fixed argv, no shell, no user input
             argv,
             cwd=str(base),
             capture_output=True,

--- a/tests/cli/test_extension_catalog.py
+++ b/tests/cli/test_extension_catalog.py
@@ -185,6 +185,25 @@ def test_fetch_git_via_injected_runner() -> None:
     assert [e.name for e in cat.entries] == ["git-ext"]
 
 
+def test_default_git_runner_uses_contained_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def run_contained(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(ec, "run_contained", run_contained)
+    result = ec._default_git_runner(["git", "clone", "--depth", "1", "url", "dest"])
+
+    assert result.returncode == 0
+    assert calls == [
+        (
+            ["git", "clone", "--depth", "1", "url", "dest"],
+            {"capture_output": True, "check": False, "timeout": ec.GIT_CLONE_TIMEOUT},
+        )
+    ]
+
+
 def test_fetch_git_clone_failure_raises() -> None:
     def git_runner(argv: list[str]) -> subprocess.CompletedProcess[bytes]:
         return subprocess.CompletedProcess(argv, 128, stdout=b"", stderr=b"fatal: repo not found")

--- a/tests/test_extension_api.py
+++ b/tests/test_extension_api.py
@@ -6,12 +6,15 @@ and internal attribute allowlist.
 
 from __future__ import annotations
 
+import os
+import subprocess
 from typing import Any
 
 import pytest
 from aelix_agent_core.harness.hooks import ToolCallResult
 from aelix_agent_core.types import AgentTool
 from aelix_ai.tools import ToolExecutionContext, ToolResult
+from aelix_coding_agent.extensions import api as api_mod
 from aelix_coding_agent.extensions.api import (
     Extension,
     ExtensionAPI,
@@ -53,6 +56,31 @@ def _make_ctx(runtime: _ExtensionRuntime | None = None) -> ExtensionContext:
         get_active_tools=lambda: ["tool_a"],
         get_system_prompt=lambda: "system",
     )
+
+
+async def test_exec_timeout_uses_contained_process_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api, _, _ = _make_api()
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def run_contained(argv: list[str], **kwargs: object) -> object:
+        calls.append((argv, kwargs))
+        raise subprocess.TimeoutExpired(argv, kwargs["timeout"], output=b"partial")
+
+    monkeypatch.setattr(api_mod, "run_contained", run_contained)
+    result = await api.exec("tool", ["arg"], cwd="work", timeout_ms=250)
+
+    assert result == api_mod.ExecResult(
+        stdout="partial", stderr="", code=124, killed=True
+    )
+    assert calls[0][0] == ["tool", "arg"]
+    assert calls[0][1]["capture_output"] is True
+    assert calls[0][1]["text"] is True
+    assert calls[0][1]["cwd"] == "work"
+    assert calls[0][1]["env"] == dict(os.environ)
+    assert calls[0][1]["timeout"] == 0.25
+    assert calls[0][1]["check"] is False
 
 
 async def _noop_execute(args: dict[str, Any], ctx: ToolExecutionContext) -> ToolResult:

--- a/tests/tools/test_process_tree_win32.py
+++ b/tests/tools/test_process_tree_win32.py
@@ -27,14 +27,19 @@ remaining ``AttributeError`` failures on the first ``windows-latest`` leg.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import signal
 import subprocess
+import sys
+import time
 from typing import Any
 
 import pytest
 from aelix_coding_agent.tools import _process_tree
-from aelix_coding_agent.tools._process_tree import kill_process_tree
+from aelix_coding_agent.tools._process_tree import kill_process_tree, run_contained
+
+from tests.process_probe import STATE_GONE, STATE_ZOMBIE, probe_state
 
 # The value only has to be the SAME one production and these assertions see.
 # On POSIX this is ``signal.SIGKILL`` itself and lending it back is a no-op; on
@@ -94,6 +99,97 @@ def test_win32_survives_a_missing_taskkill(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(subprocess, "run", boom)
 
     kill_process_tree(4321, platform="win32")  # must not raise
+
+
+def test_run_contained_timeout_reap_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pipe that never closes cannot make timeout cleanup unbounded."""
+
+    class _FakeProcess:
+        pid = 4321
+        returncode = -9
+        stdout = None
+        stderr = None
+
+        def __init__(self) -> None:
+            self.communicate_calls: list[float | None] = []
+            self.killed = False
+
+        def communicate(self, *, timeout: float | None = None) -> tuple[bytes, bytes]:
+            self.communicate_calls.append(timeout)
+            if len(self.communicate_calls) == 1:
+                raise subprocess.TimeoutExpired(
+                    ["fake"], timeout, output=b"partial", stderr=b"err"
+                )
+            raise subprocess.TimeoutExpired(
+                ["fake"], timeout, output=b"still-open", stderr=b"still-err"
+            )
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def wait(self, *, timeout: float | None = None) -> int:
+            assert timeout == _process_tree._REAP_TIMEOUT
+            return self.returncode
+
+    fake = _FakeProcess()
+    killed: list[int] = []
+    monkeypatch.setattr(_process_tree.subprocess, "Popen", lambda *a, **k: fake)
+    monkeypatch.setattr(_process_tree, "kill_process_tree", killed.append)
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        run_contained(["fake"], capture_output=True, timeout=0.01)
+
+    assert killed == [4321]
+    assert fake.killed
+    assert fake.communicate_calls == [0.01, _process_tree._REAP_TIMEOUT]
+    assert exc_info.value.output == b"still-open"
+    assert exc_info.value.stderr == b"still-err"
+
+
+def test_run_contained_timeout_kills_descendant_holding_stdout(tmp_path) -> None:
+    """The regression must cover a real descendant, not only a mocked timeout."""
+
+    pid_file = tmp_path / "grandchild.pid"
+    script = (
+        "import subprocess, sys, time; "
+        f"pid_file = {str(pid_file)!r}; "
+        "grandchild = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)']); "
+        "open(pid_file, 'w', encoding='ascii').write(str(grandchild.pid)); "
+        "print('ready', flush=True); "
+        "time.sleep(30)"
+    )
+
+    started = time.monotonic()
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_contained(
+                [sys.executable, "-c", script], capture_output=True, timeout=0.5
+            )
+        elapsed = time.monotonic() - started
+        assert elapsed < 5.0, f"timeout cleanup took too long: {elapsed:.2f}s"
+
+        deadline = time.monotonic() + 3.0
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert pid_file.exists(), "child never recorded its descendant PID"
+        grandchild_pid = int(pid_file.read_text(encoding="ascii"))
+
+        state = probe_state(grandchild_pid)
+        while state not in (STATE_GONE, STATE_ZOMBIE) and time.monotonic() < deadline:
+            time.sleep(0.05)
+            state = probe_state(grandchild_pid)
+        assert state in (STATE_GONE, STATE_ZOMBIE), (
+            f"descendant {grandchild_pid} survived timeout cleanup: {state}"
+        )
+    finally:
+        # The test's process tree should already be gone.  If setup failed before
+        # the helper could contain it, clean up only the recorded descendant.
+        if pid_file.exists():
+            with contextlib.suppress(OSError, ValueError):
+                leftover_pid = int(pid_file.read_text(encoding="ascii"))
+                kill_process_tree(leftover_pid)
 
 
 # === POSIX is unchanged =====================================================

--- a/tests/tui/test_completion.py
+++ b/tests/tui/test_completion.py
@@ -441,7 +441,7 @@ def test_fd_enumerate_builds_safe_argv(monkeypatch: Any, tmp_path: Path) -> None
         assert kwargs.get("timeout")  # a timeout is always set
         return _Proc()
 
-    monkeypatch.setattr(completion_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(completion_mod, "run_contained", _fake_run)
     out = _fd_enumerate("fd", tmp_path)
     assert out == ["src/foo.py", "README.md", "src/deep"]
     # No user-controlled pattern in the argv (injection-free).
@@ -532,7 +532,7 @@ def test_fd_failure_falls_back_to_walk(monkeypatch: Any, tmp_path: Path) -> None
     def _boom(*a: Any, **k: Any) -> None:
         raise completion_mod.subprocess.TimeoutExpired(cmd="fd", timeout=2.0)
 
-    monkeypatch.setattr(completion_mod.subprocess, "run", _boom)
+    monkeypatch.setattr(completion_mod, "run_contained", _boom)
     assert [c.text for c in _file_complete(tmp_path, "@widhel")] == [
         "@src/deep/widget_helper.py"
     ]


### PR DESCRIPTION
## Summary

- Add a shared synchronous subprocess runner that creates a contained process tree and bounds timeout cleanup.
- Route extension execution, git catalog cloning, and `fd` completion through the runner.
- Reap descendants after timeout and preserve partial stdout/stderr for existing callers.

## Validation

- `uv sync --all-packages`
- `uv run ruff check .`
- `uv run python scripts/check_types.py`
- `uv run pytest -p no:cacheprovider tests/tools/test_process_tree_win32.py tests/tui/test_completion.py tests/cli/test_extension_catalog.py tests/test_extension_api.py -q -k "not symlink"` (`206 passed`)
- Added a real Windows-compatible regression test for a descendant holding an inherited stdout pipe.

The full suite was also exercised on the local Windows host. It reported `9719 passed, 73 skipped`; the remaining failures/errors are host-specific baseline cases requiring POSIX terminal behavior or symlink privileges, while the changed target tests pass.

Closes #221
